### PR TITLE
Fix package name in installation instructions

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -5,13 +5,13 @@ Install with Pip or easy_install.
 
     .. code-block:: sh
 
-        $ pip install streams
+        $ pip install pystreams
 
 or
 
     .. code-block:: sh
 
-        $ easy_install streams
+        $ easy_install pystreams
 
 If you want, you can always download the latest bleeding edge from GitHub:
 


### PR DESCRIPTION
The package on PyPI is named `pystreams`. The package named `streams` appears to be stuck at 0.1, and is uninstallable for some reason.
