### PR TITLE
Add (optional) caching interface to Stream.

### DIFF
--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -28,6 +28,29 @@ from streams import Stream
 
 ###############################################################################
 class StreamTests(TestCase):
+    def test_no_cache(self):
+        # Make a normal stream.
+        stream = Stream.range(10)
+        # Iterate once
+        self.assertEqual(list(stream), list(range(10)))
+        # Iterate twice
+        self.assertEqual(list(stream), [])
+
+    def test_cache(self):
+        # Make a cached stream.
+        stream = Stream.range(10).cache()
+        # Iterate once
+        self.assertEqual(list(stream), list(range(10)))
+        # Iterate twice, this time from the cache.
+        self.assertEqual(list(stream), list(range(10)))
+
+        # Now, we make a new, smaller, cached stream fromm our cached stream.
+        stream = stream.cache(5)
+        # Iterate once
+        self.assertEqual(list(stream), list(range(10)))
+        # Iterate twice, this time from the cache. We get the last 5 values.
+        self.assertEqual(list(stream), list(range(5, 10)))
+
     #   Stream class methods
     def test_it_should_produce_a_range(self):
         stream = Stream.range(10)


### PR DESCRIPTION
By default, no caching is done, which maintains the original behavior. I've added the `max_cache` argument to the constructor to enable caching behavior when an integer is specified.

I've added a `.cache()` method to create a cached copy of the present iterator. By default, every element is cached, but this can be controlled, again with a `max_cache` argument.

The cache uses a(n optionally sized) deque. There may be more efficient implementations possible--it would be worthwhile for future "iterations" to research how `itertools.tee()` is implemented.

Tests pass in Python 2.6, 2.7, and 3.4.

Closes #2
